### PR TITLE
Handle non-standard xmlns declaration and bump 0.2.2 version.

### DIFF
--- a/speedparser/__init__.py
+++ b/speedparser/__init__.py
@@ -1,3 +1,3 @@
 from .speedparser import parse
-VERSION = (0,2,1)
+VERSION = (0,2,2)
 __all__ = ['parse', 'VERSION']

--- a/speedparser/speedparser.py
+++ b/speedparser/speedparser.py
@@ -606,7 +606,10 @@ class SpeedParser(object):
             if not (value.startswith('atom') and root_tag == 'rss'):
                 return value
         elif self.xmlns:
-            vers = self.xmlns.split('/')[-2].replace('.', '')
+            try:
+                vers = self.xmlns.split('/')[-2].replace('.', '')
+            except IndexError:
+                vers = ''
         tag = root_tag
         if r.attrib.get('version', None):
             vers = r.attrib['version'].replace('.', '')


### PR DESCRIPTION
Change motivated to handle "com-wordpress:feed-additions:1" xmlns.